### PR TITLE
Ensure we can hash non-strings, and make utf8 strings hash consistently.

### DIFF
--- a/SipHash.xs
+++ b/SipHash.xs
@@ -7,9 +7,19 @@
 
 #include "csiphash.c"
 
+uint64_t siphash24_sv(SV *src, SV *seed) {
+    STRLEN src_len;
+    char * src_pv= SvPV(src,src_len);
+    STRLEN seed_len;
+    char *seed_pv= SvPV(seed,seed_len);
+    assert(seed_len>=16);
+    return siphash24(src_pv, src_len, seed_pv);
+}
+
 static SV *
 siphash_as_av(SV *src, SV *seed) {
-    uint64_t hash = siphash24(SvPV_nolen(src), SvCUR(src), SvPV_nolen(seed));
+    uint64_t hash = siphash24_sv(src,seed);
+
     AV *av = newAV();
     av_extend(av, 1);
     av_store(av, 0, newSVuv(hash & 0xffffffff));
@@ -24,7 +34,7 @@ _xs_siphash64(src, seed)
 SV *src;
 SV *seed;
 CODE:
-    RETVAL = (UV)siphash24(SvPV_nolen(src), SvCUR(src), SvPV_nolen(seed));
+    RETVAL = (UV)siphash24_sv(src, seed);
 OUTPUT:
     RETVAL
 

--- a/lib/Digest/SipHash.pm
+++ b/lib/Digest/SipHash.pm
@@ -21,6 +21,10 @@ our $DEFAULT_SEED = pack 'C16', map { int( rand(256) ) } ( 0 .. 0xF );
 sub siphash {
     my $str = shift;
     my $seed = shift || $DEFAULT_SEED;
+    unless (@_) {
+        utf8::downgrade($str,1);
+        utf8::downgrade($seed,1);
+    }
     use bytes;
     $seed .= substr( $DEFAULT_SEED, length($seed) ) if length($seed) < 16;
     my $lohi = _xs_siphash_av( $str, $seed );
@@ -33,6 +37,10 @@ if (USE64BITINT) {
     *siphash64 = sub {
         my $str = shift;
         my $seed = shift || $DEFAULT_SEED;
+        unless (@_) {
+            utf8::downgrade($str,1);
+            utf8::downgrade($seed,1);
+        }
         use bytes;
         $seed .= substr( $DEFAULT_SEED, length($seed) ) if length($seed) < 16;
         return _xs_siphash64( $str, $seed );
@@ -87,8 +95,8 @@ C<:all> to all of above
 
 =head2 siphash
 
-  my ($hi, $lo) = siphash($str [, $seed]);
-  my $uint32    = siphash($str [, $seed]);
+  my ($hi, $lo) = siphash($str [, $seed][, $no_downgrade]);
+  my $uint32    = siphash($str [, $seed][, $no_downgrade]);
 
 Calculates the SipHash value of C<$src> with $<$seed>.
 
@@ -106,6 +114,17 @@ always returns the lower 32-bit first so that:
   hash_value($str) == siphash($str, hash_seed()); # scalar context
 
 always holds true when PERL_HASH_FUN_SIPHASH is in effect.
+
+=head2 About Unicode
+
+By default this module follows the same rules as Perl does regarding
+hashing, utf8 strings are passed to utf8::downgrade() with the $fail_ok
+flag set to true. This means that if the complete string can be downgraded
+to non-utf8 prior to hashing it will be, otherwise it will be left in
+utf8 form. This means that all strings which are string equivalent
+hash equivalently, and may not be what you want. In which case you can
+pass a third argument to the hash functions, which when true disables
+the downgrade behavior.
 
 =head2 siphash32
 

--- a/t/01-SipHash.t
+++ b/t/01-SipHash.t
@@ -5,7 +5,7 @@ use warnings FATAL => 'all';
 use Test::More;
 use Digest::SipHash qw/:all/;
 use constant USE64BITINT => eval { pack 'Q', 1 };
-plan tests => 8;
+plan tests => 10;
 
 my $key = pack 'C16', 0..0xf;
 my $str = "hello, world!";
@@ -26,3 +26,12 @@ SKIP:{
         is $u64, 9054994024755049184, 'siphash64';
     };
 }
+
+# test that we hash utf8 and non-utf8 consistently
+my $an_interesting_case= "\xDF";
+my $h1= siphash($an_interesting_case,$key);
+utf8::upgrade($an_interesting_case);
+my $h2= siphash($an_interesting_case,$key);
+is $h1,$h2, "We hash consistently regardless of utf8";
+my $h3= siphash($an_interesting_case,$key,1);
+isnt $h1,$h3, "We hash inconsistently at request";

--- a/t/01-SipHash.t
+++ b/t/01-SipHash.t
@@ -5,7 +5,7 @@ use warnings FATAL => 'all';
 use Test::More;
 use Digest::SipHash qw/:all/;
 use constant USE64BITINT => eval { pack 'Q', 1 };
-plan tests => 4;
+plan tests => 8;
 
 my $key = pack 'C16', 0..0xf;
 my $str = "hello, world!";
@@ -13,6 +13,11 @@ is siphash($str, $key), 0x10cf32e0, 'siphash';
 is siphash32($str, $key), 0x10cf32e0, 'siphash32';
 my ($lo, $hi) = siphash($str, $key); # 0x7da9cd17, 0x10cf32e0
 ok $lo == 0x10cf32e0 && $hi == 0x7da9cd17, 'siphash in list context';
+my @want=(3953067663,4241456352,381165788,1094629927);
+for my $i (0..3) {
+    my $hash= siphash($i,$key);
+    is $hash, $want[$i];
+}
 SKIP:{
     skip "64-bit int unsupported", 1 unless USE64BITINT;
     eval {


### PR DESCRIPTION
This PR deals with two issues, a) we segfault when hashing non-strings because SvCUR() cant be reliably used in the same statement as SvPV(), unless the sv was SvPOK prior to the statement, and b) the code silently hashes utf8 and non-utf8 strings that are perl equivalent differently. There are various arguments about what a digest module should do, but this module makes some comments about the perl hash function, so IMO it is reasonable to assume that if $str_a eq $str_b is true then siphash($str_a) == siphash($str_b) should also be true.

There is an escape hatch so it "just hashes", but by default both the key and seed argument are downgraded "gracefully" before hashing. 


